### PR TITLE
The get_connections() call can also throw an IOError

### DIFF
--- a/prometheus-tor-exporter.py
+++ b/prometheus-tor-exporter.py
@@ -110,7 +110,7 @@ class StemCollector:
             yield GaugeMetricFamily("tor_uptime",
                                     "Tor daemon uptime",
                                     value=uptime)
-        except OSError:
+        except (OSError, IOError):
             # This happens if the PID does not exists (on another machine).
             pass
         try:


### PR DESCRIPTION
As listed in the documentation of get_connections() here it can also throw an IOError